### PR TITLE
Time Based Cloud Posture - Change Investigation

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/common/api/use_latest_findings_data_view.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/api/use_latest_findings_data_view.ts
@@ -8,7 +8,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import type { DataView } from '@kbn/data-plugin/common';
-import { CSP_LATEST_FINDINGS_DATA_VIEW } from '../../../common/constants';
+import { BENCHMARK_SCORE_INDEX_DEFAULT_NS } from '../../../common/constants';
 import { CspClientPluginStartDeps } from '../../types';
 
 /**
@@ -20,7 +20,8 @@ export const useLatestFindingsDataView = () => {
   } = useKibana<CspClientPluginStartDeps>().services;
 
   const findDataView = async (): Promise<DataView> => {
-    const dataView = (await dataViews.find(CSP_LATEST_FINDINGS_DATA_VIEW))?.[0];
+    // const dataView = (await dataViews.find(CSP_LATEST_FINDINGS_DATA_VIEW))?.[0];
+    const dataView = (await dataViews.find(BENCHMARK_SCORE_INDEX_DEFAULT_NS))?.[0];
     if (!dataView) {
       throw new Error('Findings data view not found');
     }

--- a/x-pack/plugins/cloud_security_posture/public/common/hooks/use_navigate_findings.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/hooks/use_navigate_findings.ts
@@ -11,7 +11,9 @@ import { findingsNavigation } from '../navigation/constants';
 import { encodeQuery } from '../navigation/query_utils';
 import { FindingsBaseURLQuery } from '../../pages/findings/types';
 
-const getFindingsQuery = (queryValue: Query['query']): Pick<FindingsBaseURLQuery, 'query'> => {
+export const getFindingsQuery = (
+  queryValue: Query['query']
+): Pick<FindingsBaseURLQuery, 'query'> => {
   const query =
     typeof queryValue === 'string'
       ? queryValue

--- a/x-pack/plugins/cloud_security_posture/public/common/hooks/use_navigate_findings.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/hooks/use_navigate_findings.ts
@@ -20,7 +20,7 @@ export const getFindingsQuery = (
       : // TODO: use a tested query builder instead ASAP
         Object.entries(queryValue)
           .reduce<string[]>((a, [key, value]) => {
-            a.push(`${key}: "${value}"`);
+            a.push(`${key} : ${value}`);
             return a;
           }, [])
           .join(' and ');

--- a/x-pack/plugins/cloud_security_posture/public/components/short_id_badge.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/short_id_badge.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { copyToClipboard, EuiBadge } from '@elastic/eui';
+import React from 'react';
+
+export const ShortIdBadge = ({ value }) => (
+  <EuiBadge
+    title={value}
+    onClick={() => copyToClipboard(value)}
+    iconOnClick={() => copyToClipboard(value)}
+    iconType="copy"
+    iconSide="right"
+    color="hollow"
+  >
+    {value.split('-')[0]}
+  </EuiBadge>
+);

--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/compliance_charts/cases_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/compliance_charts/cases_table.tsx
@@ -6,24 +6,47 @@
  */
 
 import React from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
-import { EuiIcon } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n-react';
+import { EuiNotificationEvent } from '@elastic/eui';
+import { ShortIdBadge } from '../../../components/short_id_badge';
 
-export const CasesTable = () => {
+export const CasesTable = ({ changes, handleInvestigateClick }) => {
+  console.log(changes);
   return (
-    <EuiFlexGroup direction="column" justifyContent="center" alignItems="center">
-      <EuiFlexItem grow={false}>
-        <EuiIcon type="visualizeApp" size="xl" />
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <EuiText size="xs">
-          <FormattedMessage
-            id="xpack.csp.dashboard.casesTable.placeholderTitle"
-            defaultMessage="Coming soon"
+    <div>
+      {changes.map((e) => {
+        return (
+          <EuiNotificationEvent
+            key={e.x}
+            id={e.x}
+            type={'Warning'}
+            // severity={<ShortIdBadge value={e.x} />}
+            badgeColor={'warning'}
+            iconType={'logoSecurity'}
+            time={`Last hour`}
+            // title={
+            //   <>
+            //     <ShortIdBadge value={e.x} />{' '}
+            //     <span style={{ fontWeight: 400, fontSize: 12 }}>
+            //       Evaluation was changed recently
+            //     </span>
+            //   </>
+            // }
+            isRead={false}
+            primaryAction={'Click here to investigate cycles for this finding'}
+            messages={[
+              <>
+                <ShortIdBadge value={e.x} /> <span>Evaluation was changed recently</span>
+              </>,
+            ]}
+            // onRead={onRead}
+            // onOpenContextMenu={onOpenContextMenu}
+            onClickPrimaryAction={(v) => handleInvestigateClick(v, e)}
           />
-        </EuiText>
-      </EuiFlexItem>
-    </EuiFlexGroup>
+        );
+      })}
+    </div>
   );
 };
+{
+  /* <ShortIdBadge value={event.x} />*/
+}

--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/compliance_charts/cloud_posture_score_chart.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/compliance_charts/cloud_posture_score_chart.tsx
@@ -112,7 +112,13 @@ const convertTrendToEpochTime = (trend: PostureTrend) => ({
   timestamp: moment(trend.timestamp).valueOf(),
 });
 
-const ComplianceTrendChart = ({ trend }: { trend: PostureTrend[] }) => {
+const ComplianceTrendChart = ({
+  trend,
+  onTrendElementClick,
+}: {
+  trend: PostureTrend[];
+  onTrendElementClick: any;
+}) => {
   const epochTimeTrend = trend.map(convertTrendToEpochTime);
   const {
     services: { charts },
@@ -121,6 +127,7 @@ const ComplianceTrendChart = ({ trend }: { trend: PostureTrend[] }) => {
   return (
     <Chart>
       <Settings
+        onElementClick={onTrendElementClick}
         theme={charts.theme.useChartsTheme()}
         baseTheme={charts.theme.useChartsBaseTheme()}
         showLegend={false}
@@ -166,6 +173,7 @@ export const CloudPostureScoreChart = ({
   trend,
   id,
   partitionOnElementClick,
+  onTrendElementClick,
 }: CloudPostureScoreChartProps) => (
   <EuiFlexGroup direction="column" gutterSize="none">
     <EuiFlexItem grow={4}>
@@ -180,7 +188,7 @@ export const CloudPostureScoreChart = ({
     </EuiFlexItem>
     <EuiHorizontalRule margin="xs" />
     <EuiFlexItem grow={6}>
-      <ComplianceTrendChart trend={trend} />
+      <ComplianceTrendChart trend={trend} onTrendElementClick={onTrendElementClick} />
     </EuiFlexItem>
   </EuiFlexGroup>
 );

--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmarks_section.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmarks_section.tsx
@@ -38,6 +38,13 @@ export const BenchmarksSection = ({
   const { euiTheme } = useEuiTheme();
   const navToFindings = useNavigateFindings();
 
+  const handleTrendElementClick = (clusterId, elements) => {
+    const [element] = elements;
+    const [elementData] = element;
+
+    navToFindings({ cluster_id: clusterId, snapshot_id: elementData.datum.snapshot });
+  };
+
   const handleElementClick = (clusterId: string, elements: PartitionElementEvent[]) => {
     const [element] = elements;
     const [layerValue] = element;
@@ -110,6 +117,9 @@ export const BenchmarksSection = ({
                       trend={cluster.trend}
                       partitionOnElementClick={(elements) =>
                         handleElementClick(cluster.meta.clusterId, elements)
+                      }
+                      onTrendElementClick={(elements) =>
+                        handleTrendElementClick(cluster.meta.clusterId, elements)
                       }
                     />
                   </ChartPanel>

--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/summary_section.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/summary_section.tsx
@@ -27,6 +27,13 @@ const summarySectionWrapperStyle = {
 export const SummarySection = ({ complianceData }: { complianceData: ComplianceDashboardData }) => {
   const navToFindings = useNavigateFindings();
 
+  const handleTrendElementClick = (elements) => {
+    const [element] = elements;
+    const [elementData] = element;
+
+    navToFindings({ snapshot_id: elementData.datum.snapshot });
+  };
+
   const handleElementClick = (elements: PartitionElementEvent[]) => {
     const [element] = elements;
     const [layerValue] = element;
@@ -59,6 +66,7 @@ export const SummarySection = ({ complianceData }: { complianceData: ComplianceD
             data={complianceData.stats}
             trend={complianceData.trend}
             partitionOnElementClick={handleElementClick}
+            onTrendElementClick={handleTrendElementClick}
           />
         </ChartPanel>
       </EuiFlexItem>

--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/summary_section.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/summary_section.tsx
@@ -53,6 +53,14 @@ export const SummarySection = ({ complianceData }: { complianceData: ComplianceD
     navToFindings({ 'result.evaluation': RULE_FAILED });
   };
 
+  const handleInvestigateClick = (e, change) => {
+    const snapshots = change.s.map((snap) => `snapshot_id : ${snap}`);
+
+    const query = `_unique_id : "${e}" and (${snapshots.join(' or ')})`;
+
+    navToFindings(query);
+  };
+
   return (
     <EuiFlexGrid columns={3} style={summarySectionWrapperStyle}>
       <EuiFlexItem>
@@ -90,7 +98,10 @@ export const SummarySection = ({ complianceData }: { complianceData: ComplianceD
             defaultMessage: 'Open Cases',
           })}
         >
-          <CasesTable />
+          <CasesTable
+            changes={complianceData.changes}
+            handleInvestigateClick={handleInvestigateClick}
+          />
         </ChartPanel>
       </EuiFlexItem>
     </EuiFlexGrid>

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/es_pit/use_findings_es_pit.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/es_pit/use_findings_es_pit.ts
@@ -7,7 +7,7 @@
 
 import { useCallback, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { CSP_LATEST_FINDINGS_DATA_VIEW, ES_PIT_ROUTE_PATH } from '../../../../common/constants';
+import { BENCHMARK_SCORE_INDEX_DEFAULT_NS, ES_PIT_ROUTE_PATH } from '../../../../common/constants';
 import { useKibana } from '../../../common/hooks/use_kibana';
 import { FINDINGS_PIT_KEEP_ALIVE } from '../constants';
 
@@ -29,7 +29,11 @@ export const useFindingsEsPit = (queryKey: string) => {
     ['findingsPitQuery', queryKey],
     () =>
       http.post<string>(ES_PIT_ROUTE_PATH, {
-        query: { index_name: CSP_LATEST_FINDINGS_DATA_VIEW, keep_alive: FINDINGS_PIT_KEEP_ALIVE },
+        // query: { index_name: CSP_LATEST_FINDINGS_DATA_VIEW, keep_alive: FINDINGS_PIT_KEEP_ALIVE },
+        query: {
+          index_name: BENCHMARK_SCORE_INDEX_DEFAULT_NS,
+          keep_alive: FINDINGS_PIT_KEEP_ALIVE,
+        },
       }),
     {
       enabled: !isPitIdSet,

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/findings_flyout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/findings_flyout.tsx
@@ -20,9 +20,23 @@ import {
   EuiCodeBlock,
   EuiMarkdownFormat,
   EuiIcon,
+  EuiTimeline,
+  EuiAvatar,
+  euiPaletteColorBlindBehindText,
+  EuiPanel,
+  EuiText,
+  EuiButton,
+  EuiModal,
+  EuiModalHeader,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeaderTitle,
 } from '@elastic/eui';
 import { assertNever } from '@kbn/std';
 import { i18n } from '@kbn/i18n';
+import moment from 'moment';
+import { CSP_MOMENT_FORMAT } from '../../../common/constants';
+import { useLatestFindings } from '../latest_findings/use_latest_findings';
 import cisLogoIcon from '../../../assets/icons/cis_logo.svg';
 import type { CspFinding } from '../types';
 import { CspEvaluationBadge } from '../../../components/csp_evaluation_badge';
@@ -58,6 +72,12 @@ const tabs = [
       defaultMessage: 'JSON',
     }),
   },
+  {
+    id: 'timeline',
+    title: i18n.translate('xpack.csp.findings.findingsFlyout.timelineTabTitle', {
+      defaultMessage: 'Timeline',
+    }),
+  },
 ] as const;
 
 type FindingsTab = typeof tabs[number];
@@ -65,6 +85,8 @@ type FindingsTab = typeof tabs[number];
 interface FindingFlyoutProps {
   onClose(): void;
   findings: CspFinding;
+  latestSnapshots: number[];
+  selectedSnapshot: number;
 }
 
 export const CodeBlock: React.FC<PropsOf<typeof EuiCodeBlock>> = (props) => (
@@ -86,7 +108,162 @@ export const CisKubernetesIcons = ({ benchmarkId }: { benchmarkId: BenchmarkId }
   </EuiFlexGroup>
 );
 
-const FindingsTab = ({ tab, findings }: { findings: CspFinding; tab: FindingsTab }) => {
+const timelineItemsForFinding = (matchingFindings, setShowModal) => {
+  return matchingFindings.map((mf, index) => {
+    const evalu = mf.result.evaluation;
+    // const hasChanged = true;
+    const hasChanged =
+      index !== matchingFindings.length - 1 &&
+      evalu !== matchingFindings[index + 1].result.evaluation;
+
+    const colorBlindBehindText = euiPaletteColorBlindBehindText({
+      sortBy: 'natural',
+    });
+
+    return {
+      icon: hasChanged ? (
+        <EuiAvatar name="Alert" iconType="alert" color={colorBlindBehindText[9]} />
+      ) : (
+        'check'
+      ),
+      children: (
+        <>
+          <EuiPanel hasShadow={false} hasBorder>
+            <EuiText color="subdued" size={'xs'} style={{ marginBottom: 10 }}>{`${moment(
+              mf.snapshot_id
+            ).format(CSP_MOMENT_FORMAT)} | snapshot id: ${mf.snapshot_id}`}</EuiText>
+            <span>{'This finding '}</span>
+            {hasChanged ? <strong>{'has changed!'}</strong> : <strong>{'did not change'}</strong>}
+            {index !== matchingFindings.length - 1 && hasChanged && (
+              <>
+                <div style={{ display: 'flex', gap: 4, marginTop: 10 }}>
+                  <div>{`It used to be`}</div>
+                  <CspEvaluationBadge type={matchingFindings[index + 1].result.evaluation} />
+                  <div>{`but as for ${moment(mf.snapshot_id).fromNow()}, it is now`}</div>
+                  <CspEvaluationBadge type={evalu} />
+                </div>
+                <div style={{ marginTop: 25, gap: 6, display: 'flex' }}>
+                  {mf.result.evaluation === 'failed' && (
+                    <EuiButton fill size={'s'} iconType={'starFilledSpace'}>
+                      Remedy
+                    </EuiButton>
+                  )}
+                  <EuiButton size={'s'} iconType={'alert'}>
+                    Alert on next change
+                  </EuiButton>
+                  <EuiButton
+                    onClick={() =>
+                      setShowModal({
+                        currentFinding: mf,
+                        previousFinding: matchingFindings[index + 1],
+                      })
+                    }
+                    size={'s'}
+                    iconType={'inspect'}
+                  >
+                    Investigate change
+                  </EuiButton>
+                </div>
+              </>
+            )}
+          </EuiPanel>
+        </>
+      ),
+    };
+  });
+};
+
+const TimelineTab = ({ data: finding, snapshots }) => {
+  const [showModal, setShowModal] = useState(false);
+
+  const findingTimeline = useLatestFindings({
+    sort: { field: 'snapshot_id', direction: 'desc' },
+    size: 10,
+    query: {
+      bool: {
+        filter: [
+          {
+            bool: {
+              filter: [
+                {
+                  bool: {
+                    should: [
+                      {
+                        match_phrase: {
+                          resource_id: finding.resource.id,
+                        },
+                      },
+                    ],
+                    minimum_should_match: 1,
+                  },
+                },
+                {
+                  bool: {
+                    should: [
+                      {
+                        match_phrase: {
+                          'rule.id': finding.rule.id,
+                        },
+                      },
+                    ],
+                    minimum_should_match: 1,
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  });
+
+  const matchingFindings = findingTimeline.data?.page;
+
+  if (!matchingFindings) return 'Loading';
+
+  return (
+    <>
+      <EuiTimeline items={timelineItemsForFinding(matchingFindings, setShowModal)} />
+      {showModal && (
+        <EuiModal onClose={() => setShowModal(false)}>
+          <EuiModalHeader>
+            <EuiModalHeaderTitle>
+              <h1>Modal title</h1>
+            </EuiModalHeaderTitle>
+          </EuiModalHeader>
+
+          <EuiModalBody>
+            <EuiSpacer />
+            <div style={{ display: 'flex' }}>
+              <EuiCodeBlock language="html" isCopyable>
+                {showModal.previousFinding.result.evaluation}
+              </EuiCodeBlock>
+              <EuiCodeBlock language="html" isCopyable>
+                {showModal.currentFinding.result.evaluation}
+              </EuiCodeBlock>
+            </div>
+          </EuiModalBody>
+
+          <EuiModalFooter>
+            <EuiButton onClick={() => setShowModal(false)} fill>
+              Close
+            </EuiButton>
+          </EuiModalFooter>
+        </EuiModal>
+      )}
+    </>
+  );
+};
+
+const FindingsTab = ({
+  tab,
+  findings,
+  snapshots,
+}: {
+  findings: CspFinding;
+  tab: FindingsTab;
+  snapshots: any;
+}) => {
   switch (tab.id) {
     case 'overview':
       return <OverviewTab data={findings} />;
@@ -96,41 +273,54 @@ const FindingsTab = ({ tab, findings }: { findings: CspFinding; tab: FindingsTab
       return <ResourceTab data={findings} />;
     case 'json':
       return <JsonTab data={findings} />;
+    case 'timeline':
+      return <TimelineTab data={findings} snapshots={snapshots} />;
     default:
       assertNever(tab);
   }
 };
 
-export const FindingsRuleFlyout = ({ onClose, findings }: FindingFlyoutProps) => {
+export const FindingsRuleFlyout = ({
+  onClose,
+  findings,
+  latestSnapshots,
+  selectedSnapshot,
+}: FindingFlyoutProps) => {
   const [tab, setTab] = useState<FindingsTab>(tabs[0]);
 
   return (
-    <EuiFlyout ownFocus={false} onClose={onClose}>
-      <EuiFlyoutHeader>
-        <EuiFlexGroup alignItems="center">
-          <EuiFlexItem grow={false}>
-            <CspEvaluationBadge type={findings.result.evaluation} />
-          </EuiFlexItem>
-          <EuiFlexItem grow style={{ minWidth: 0 }}>
-            <EuiTitle size="m" className="eui-textTruncate">
-              <EuiTextColor color="primary" title={findings.rule.name}>
-                {findings.rule.name}
-              </EuiTextColor>
-            </EuiTitle>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-        <EuiSpacer />
-        <EuiTabs>
-          {tabs.map((v) => (
-            <EuiTab key={v.id} isSelected={tab.id === v.id} onClick={() => setTab(v)}>
-              {v.title}
-            </EuiTab>
-          ))}
-        </EuiTabs>
-      </EuiFlyoutHeader>
-      <EuiFlyoutBody key={tab.id}>
-        <FindingsTab tab={tab} findings={findings} />
-      </EuiFlyoutBody>
-    </EuiFlyout>
+    <>
+      <EuiFlyout ownFocus={false} onClose={onClose}>
+        <EuiFlyoutHeader>
+          <EuiFlexGroup alignItems="center">
+            <EuiFlexItem grow={false}>
+              <CspEvaluationBadge type={findings.result.evaluation} />
+            </EuiFlexItem>
+            <EuiFlexItem grow style={{ minWidth: 0 }}>
+              <EuiTitle size="m" className="eui-textTruncate">
+                <EuiTextColor color="primary" title={findings.rule.name}>
+                  {findings.rule.name}
+                </EuiTextColor>
+              </EuiTitle>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+          <EuiSpacer />
+          <EuiTabs>
+            {tabs.map((v) => (
+              <EuiTab key={v.id} isSelected={tab.id === v.id} onClick={() => setTab(v)}>
+                {v.title}
+              </EuiTab>
+            ))}
+          </EuiTabs>
+        </EuiFlyoutHeader>
+        <EuiFlyoutBody key={tab.id}>
+          <FindingsTab
+            tab={tab}
+            findings={findings}
+            snapshots={{ selected: selectedSnapshot, latest: latestSnapshots }}
+          />
+        </EuiFlyoutBody>
+      </EuiFlyout>
+    </>
   );
 };

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/findings_flyout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/findings_flyout.tsx
@@ -146,7 +146,7 @@ const timelineItemsForFinding = (matchingFindings, setShowModal) => {
                 <div style={{ marginTop: 25, gap: 6, display: 'flex' }}>
                   {mf.result.evaluation === 'failed' && (
                     <EuiButton fill size={'s'} iconType={'bug'}>
-                      Remedy
+                      Remediate
                     </EuiButton>
                   )}
                   <EuiButton size={'s'} iconType={'alert'}>
@@ -291,7 +291,7 @@ const TimelineTab = ({ data: finding, snapshots }) => {
           <EuiModalFooter>
             <EuiButton iconType={'alert'}>Alert on next change</EuiButton>
             {showModal.currentFinding.result.evaluation === 'failed' && (
-              <EuiButton iconType={'bug'}>Remedy</EuiButton>
+              <EuiButton iconType={'bug'}>Remediate</EuiButton>
             )}
             <EuiButton onClick={() => setShowModal(false)} fill>
               Close

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/findings_flyout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout/findings_flyout.tsx
@@ -35,6 +35,7 @@ import {
 import { assertNever } from '@kbn/std';
 import { i18n } from '@kbn/i18n';
 import moment from 'moment';
+import { css } from '@emotion/react';
 import { CSP_MOMENT_FORMAT } from '../../../common/constants';
 import { useLatestFindings } from '../latest_findings/use_latest_findings';
 import cisLogoIcon from '../../../assets/icons/cis_logo.svg';
@@ -144,7 +145,7 @@ const timelineItemsForFinding = (matchingFindings, setShowModal) => {
                 </div>
                 <div style={{ marginTop: 25, gap: 6, display: 'flex' }}>
                   {mf.result.evaluation === 'failed' && (
-                    <EuiButton fill size={'s'} iconType={'starFilledSpace'}>
+                    <EuiButton fill size={'s'} iconType={'bug'}>
                       Remedy
                     </EuiButton>
                   )}
@@ -225,26 +226,73 @@ const TimelineTab = ({ data: finding, snapshots }) => {
     <>
       <EuiTimeline items={timelineItemsForFinding(matchingFindings, setShowModal)} />
       {showModal && (
-        <EuiModal onClose={() => setShowModal(false)}>
-          <EuiModalHeader>
+        <EuiModal
+          onClose={() => setShowModal(false)}
+          maxWidth={1600}
+          css={css`
+            .euiModal .euiModal__flex {
+              max-height: 90vh;
+            }
+          `}
+        >
+          <EuiModalHeader style={{ display: 'flex', justifyContent: 'flex-start', gap: 20 }}>
+            <EuiIcon type="searchProfilerApp" size="xxl" />
             <EuiModalHeaderTitle>
-              <h1>Modal title</h1>
+              <h1>Investigate Change</h1>
             </EuiModalHeaderTitle>
           </EuiModalHeader>
-
           <EuiModalBody>
-            <EuiSpacer />
-            <div style={{ display: 'flex' }}>
-              <EuiCodeBlock language="html" isCopyable>
-                {showModal.previousFinding.result.evaluation}
-              </EuiCodeBlock>
-              <EuiCodeBlock language="html" isCopyable>
-                {showModal.currentFinding.result.evaluation}
-              </EuiCodeBlock>
+            <EuiSpacer size="xs" />
+            <div style={{ display: 'flex', gap: 20 }}>
+              {/* previous */}
+              <EuiPanel hasShadow={false} hasBorder>
+                <div style={{ width: '100%', display: 'flex', justifyContent: 'space-between' }}>
+                  <EuiTitle size="s">
+                    <h5>{`Previous State - ${moment(
+                      showModal.previousFinding.snapshot_id
+                    ).fromNow()}`}</h5>
+                  </EuiTitle>
+                  <CspEvaluationBadge type={showModal.previousFinding.result.evaluation} />
+                </div>
+                <EuiSpacer size="xs" />
+                <EuiText color="subdued" size={'xs'} style={{ marginBottom: 10 }}>{`${moment(
+                  showModal.previousFinding.snapshot_id
+                ).format(CSP_MOMENT_FORMAT)} | snapshot id: ${
+                  showModal.previousFinding.snapshot_id
+                }`}</EuiText>
+                <EuiCodeBlock language="json" lineNumbers isCopyable overflowHeight={400}>
+                  {JSON.stringify(showModal.previousFinding, null, 2)}
+                </EuiCodeBlock>
+              </EuiPanel>
+
+              {/* current */}
+              <EuiPanel hasShadow={false} hasBorder>
+                <div style={{ width: '100%', display: 'flex', justifyContent: 'space-between' }}>
+                  <EuiTitle size="s">
+                    <h5>{`Investigated State - ${moment(
+                      showModal.currentFinding.snapshot_id
+                    ).fromNow()}`}</h5>
+                  </EuiTitle>
+                  <CspEvaluationBadge type={showModal.currentFinding.result.evaluation} />
+                </div>
+                <EuiSpacer size="xs" />
+                <EuiText color="subdued" size={'xs'} style={{ marginBottom: 10 }}>{`${moment(
+                  showModal.currentFinding.snapshot_id
+                ).format(CSP_MOMENT_FORMAT)} | snapshot id: ${
+                  showModal.currentFinding.snapshot_id
+                }`}</EuiText>
+                <EuiCodeBlock language="json" lineNumbers isCopyable overflowHeight={400}>
+                  {JSON.stringify(showModal.currentFinding, null, 2)}
+                </EuiCodeBlock>
+              </EuiPanel>
             </div>
           </EuiModalBody>
 
           <EuiModalFooter>
+            <EuiButton iconType={'alert'}>Alert on next change</EuiButton>
+            {showModal.currentFinding.result.evaluation === 'failed' && (
+              <EuiButton iconType={'bug'}>Remedy</EuiButton>
+            )}
             <EuiButton onClick={() => setShowModal(false)} fill>
               Close
             </EuiButton>

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_container.tsx
@@ -194,6 +194,7 @@ export const LatestFindingsContainer = ({ dataView }: FindingsBaseProps) => {
       <FindingsSearchBar
         dataView={dataView}
         setQuery={(query) => {
+          console.log(query);
           setUrlQuery({ ...query, pageIndex: 0 });
         }}
         loading={findingsGroupByNone.isFetching}
@@ -253,6 +254,8 @@ export const LatestFindingsContainer = ({ dataView }: FindingsBaseProps) => {
           )}
           <EuiSpacer />
           <FindingsTable
+            latestSnapshots={latestSnapshots}
+            selectedSnapshot={getValueOfSelectedFromQuery(urlQuery)}
             loading={findingsGroupByNone.isFetching}
             items={findingsGroupByNone.data?.page || []}
             pagination={getPaginationTableParams({

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_container.tsx
@@ -52,6 +52,7 @@ export const getDefaultQuery = ({
 const MAX_ITEMS = 500;
 
 export const LatestFindingsContainer = ({ dataView }: FindingsBaseProps) => {
+  // const latestSnapshots =
   const getPersistedDefaultQuery = usePersistedQuery(getDefaultQuery);
   const { urlQuery, setUrlQuery } = useUrlQuery(getPersistedDefaultQuery);
 

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_container.tsx
@@ -6,7 +6,14 @@
  */
 import React, { useMemo } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { EuiBottomBar, EuiSpacer, EuiText } from '@elastic/eui';
+import {
+  EuiBottomBar,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSpacer,
+  EuiSuperSelect,
+  EuiText,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { CloudPosturePageTitle } from '../../../components/cloud_posture_page_title';
 import type { FindingsBaseProps } from '../types';
@@ -93,7 +100,50 @@ export const LatestFindingsContainer = ({ dataView }: FindingsBaseProps) => {
       {error && <ErrorCallout error={error} />}
       {!error && (
         <>
-          <FindingsGroupBySelector type="default" />
+          <EuiFlexGroup>
+            <EuiFlexItem>
+              <FindingsGroupBySelector type="default" />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiSuperSelect
+                prepend={'Check Cycle'}
+                options={[
+                  {
+                    value: 'option_one',
+                    inputDisplay: 'A few seconds ago - Latest',
+                    dropdownDisplay: (
+                      <>
+                        <strong>A few seconds ago - Latest Cycle</strong>
+                        <EuiText size="s" color="subdued">
+                          <p>92sdaf25-2345w-fdas-1345wdsf</p>
+                        </EuiText>
+                      </>
+                    ),
+                  },
+                  {
+                    value: 'option_two',
+                    inputDisplay: 'An hour ago',
+                    dropdownDisplay: (
+                      <>
+                        <strong>An hour ago</strong>
+                        <EuiText size="s" color="subdued">
+                          <p>dsf5sdg-sd90sd-234la-vsd30sk</p>
+                        </EuiText>
+                      </>
+                    ),
+                  },
+                ]}
+                valueOfSelected={'option_one'}
+                // onChange={() => {
+                //   setUrlQuery({
+                //     ...urlQuery,
+                //     query: { language: 'kuery', query: "cycle_id: 'test'" },
+                //   });
+                // }}
+                hasDividers
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
           {findingsGroupByNone.isSuccess && !!findingsGroupByNone.data.page.length && (
             <FindingsDistributionBar
               {...{

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_container.tsx
@@ -4,7 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
 import React, { useEffect, useMemo } from 'react';
+import moment from 'moment';
 import { FormattedMessage } from '@kbn/i18n-react';
 import {
   EuiBottomBar,
@@ -15,7 +17,6 @@ import {
   EuiText,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { getFindingsQuery } from '../../../common/hooks/use_navigate_findings';
 import { useCspSetupStatusApi } from '../../../common/api/use_setup_status_api';
 import { CloudPosturePageTitle } from '../../../components/cloud_posture_page_title';
 import type { FindingsBaseProps } from '../types';
@@ -52,6 +53,92 @@ export const getDefaultQuery = ({
 });
 
 const MAX_ITEMS = 500;
+const NO_SNAPSHOT_ID = 'no_snapshot_id';
+
+const getCycles = (cycles) => {
+  const cycleOptions = cycles.map((c) => ({
+    value: c.toString(),
+    inputDisplay: moment(c).fromNow(),
+    dropdownDisplay: (
+      <>
+        <strong>{moment(c).fromNow()}</strong>
+        <EuiText size="s" color="subdued">
+          <p>{c}</p>
+        </EuiText>
+      </>
+    ),
+  }));
+
+  cycleOptions.unshift({
+    value: NO_SNAPSHOT_ID,
+    inputDisplay: 'All Results',
+    dropdownDisplay: (
+      <>
+        <strong>{'All Results'}</strong>
+        <EuiText size="s" color="subdued">
+          <p>{'No cycle ID, showing all findings'}</p>
+        </EuiText>
+      </>
+    ),
+  });
+
+  return cycleOptions;
+};
+
+const getValueOfSelectedFromQuery = (urlQuery) => {
+  const hasSnapshot = urlQuery.query.query.includes('snapshot_id');
+  if (!hasSnapshot) return NO_SNAPSHOT_ID;
+
+  const queryString = urlQuery.query.query;
+  const splitQuery = queryString.split(' ');
+  const snapshotIdIndex = splitQuery.findIndex((e) => e === 'snapshot_id');
+
+  return splitQuery[snapshotIdIndex + 2];
+};
+
+// this takes the urlQuery.query.query string
+const getUrlQueryqueryqueryWithSnapshot = (urlQueryqueryquery, snapshotId) => {
+  const hasSnapshot = urlQueryqueryquery.includes('snapshot_id');
+
+  return {
+    query: {
+      language: 'kuery',
+      query: hasSnapshot
+        ? urlQueryqueryquery
+        : urlQueryqueryquery.length
+        ? `${urlQueryqueryquery} and snapshot_id : ${snapshotId}`
+        : '',
+    },
+  };
+};
+
+const replaceUrlqueryqueryquerySnapshot = (urlQueryqueryquery, snapshotId) => {
+  const hasQuery = urlQueryqueryquery.length;
+  const hasSnapshot = urlQueryqueryquery.includes('snapshot_id');
+  if (!hasQuery && !hasSnapshot) return `snapshot_id : ${snapshotId}`;
+  if (hasQuery && !hasSnapshot) return `${urlQueryqueryquery} and snapshot_id : ${snapshotId}`;
+
+  const splitQuery = urlQueryqueryquery.split(' ');
+  const snapshotIdIndex = splitQuery.findIndex((e) => e === 'snapshot_id');
+  splitQuery[snapshotIdIndex + 2] = snapshotId;
+  return splitQuery.join(' ');
+};
+
+const removeUrlqueryqueryquerySnapshot = (urlQueryqueryquery) => {
+  const hasSnapshot = urlQueryqueryquery?.includes('snapshot_id');
+  if (!hasSnapshot) return;
+
+  const splitQuery = urlQueryqueryquery.split(' ');
+  const snapshotIdIndex = splitQuery.findIndex((e) => e === 'snapshot_id');
+
+  if (splitQuery[snapshotIdIndex - 1] === 'and') {
+    splitQuery.splice(snapshotIdIndex - 1, 4);
+  } else {
+    splitQuery.splice(snapshotIdIndex, 3);
+  }
+
+  return splitQuery.join(' ');
+};
 
 export const LatestFindingsContainer = ({ dataView }: FindingsBaseProps) => {
   const {
@@ -61,27 +148,13 @@ export const LatestFindingsContainer = ({ dataView }: FindingsBaseProps) => {
   const getPersistedDefaultQuery = usePersistedQuery(getDefaultQuery);
   const { urlQuery, setUrlQuery } = useUrlQuery(getPersistedDefaultQuery);
 
-  console.log(urlQuery);
-  const test = getFindingsQuery({ a: 2 });
-  console.log({ test });
-
   useEffect(() => {
-    const actualQuery = urlQuery.query.query;
-    const hasSnapshot = actualQuery.includes('snapshot_id');
-
-    const test = getFindingsQuery({
-      ...(!hasSnapshot && { snapshot_id: latestSnapshot }),
-    });
-
+    // makes sure a snapshot id is in the search bar
     setUrlQuery({
       ...urlQuery,
-      query: {
-        language: 'kuery',
-        query: `${hasSnapshot ? '' : `snapshot_id: ${latestSnapshot}`} ${
-          actualQuery.length ? `and ${actualQuery} ` : ''
-        }`,
-      },
+      ...getUrlQueryqueryqueryWithSnapshot(urlQuery.query.query, latestSnapshot),
     });
+    // ---
   }, []);
 
   /**
@@ -136,38 +209,26 @@ export const LatestFindingsContainer = ({ dataView }: FindingsBaseProps) => {
             <EuiFlexItem grow={false}>
               <EuiSuperSelect
                 prepend={'Check Cycle'}
-                options={[
-                  {
-                    value: 'option_one',
-                    inputDisplay: 'A few seconds ago - Latest',
-                    dropdownDisplay: (
-                      <>
-                        <strong>A few seconds ago - Latest Cycle</strong>
-                        <EuiText size="s" color="subdued">
-                          <p>92sdaf25-2345w-fdas-1345wdsf</p>
-                        </EuiText>
-                      </>
-                    ),
-                  },
-                  {
-                    value: 'option_two',
-                    inputDisplay: 'An hour ago',
-                    dropdownDisplay: (
-                      <>
-                        <strong>An hour ago</strong>
-                        <EuiText size="s" color="subdued">
-                          <p>dsf5sdg-sd90sd-234la-vsd30sk</p>
-                        </EuiText>
-                      </>
-                    ),
-                  },
-                ]}
-                valueOfSelected={'option_one'}
-                onChange={() => {
-                  setUrlQuery({
-                    ...urlQuery,
-                    query: { language: 'kuery', query: "cycle_id: 'test'" },
-                  });
+                options={getCycles(latestSnapshots)}
+                valueOfSelected={getValueOfSelectedFromQuery(urlQuery)}
+                onChange={(o) => {
+                  if (o === NO_SNAPSHOT_ID) {
+                    setUrlQuery({
+                      ...urlQuery,
+                      query: {
+                        language: 'kuery',
+                        query: removeUrlqueryqueryquerySnapshot(urlQuery.query.query),
+                      },
+                    });
+                  } else {
+                    setUrlQuery({
+                      ...urlQuery,
+                      query: {
+                        language: 'kuery',
+                        query: replaceUrlqueryqueryquerySnapshot(urlQuery.query.query, o),
+                      },
+                    });
+                  }
                 }}
                 hasDividers
               />

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_table.tsx
@@ -34,6 +34,8 @@ interface Props {
   sorting: TableProps['sorting'];
   setTableOptions(options: CriteriaWithPagination<CspFinding>): void;
   onAddFilter: OnAddFilter;
+  latestSnapshots: number[];
+  selectedSnapshot: number;
 }
 
 const FindingsTableComponent = ({
@@ -43,6 +45,8 @@ const FindingsTableComponent = ({
   sorting,
   setTableOptions,
   onAddFilter,
+  latestSnapshots,
+  selectedSnapshot,
 }: Props) => {
   const [selectedFinding, setSelectedFinding] = useState<CspFinding>();
 
@@ -107,6 +111,8 @@ const FindingsTableComponent = ({
       />
       {selectedFinding && (
         <FindingsRuleFlyout
+          selectedSnapshot={selectedSnapshot}
+          latestSnapshots={latestSnapshots}
           findings={selectedFinding}
           onClose={() => setSelectedFinding(undefined)}
         />

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/latest_findings_table.tsx
@@ -72,6 +72,7 @@ const FindingsTableComponent = ({
       baseFindingsColumns['rule.section'],
       baseFindingsColumns['rule.tags'],
       createColumnWithFilters(baseFindingsColumns.cluster_id, { onAddFilter }),
+      createColumnWithFilters(baseFindingsColumns._unique_id, { onAddFilter }),
       baseFindingsColumns['@timestamp'],
     ],
     [onAddFilter]

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/use_latest_findings.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/latest_findings/use_latest_findings.ts
@@ -106,7 +106,7 @@ export const useLatestFindings = (options: UseFindingsOptions) => {
       };
     },
     {
-      enabled: options.enabled,
+      enabled: true,
       keepPreviousData: true,
       onError: (err: Error) => showErrorToast(toasts, err),
       onSuccess: ({ newPitId }) => {

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/layout/findings_layout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/layout/findings_layout.tsx
@@ -12,13 +12,13 @@ import {
   EuiTableActionsColumnType,
   EuiTableFieldDataColumnType,
   EuiTitle,
-  EuiToolTip,
   PropsOf,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { euiThemeVars } from '@kbn/ui-theme';
 import type { Serializable } from '@kbn/utility-types';
+import { ShortIdBadge } from '../../../components/short_id_badge';
 import { getPrimaryRuleTags } from '../../../common/utils/get_primary_rule_tags';
 import { TimestampTableCell } from '../../../components/timestamp_table_cell';
 import { ColumnNameWithTooltip } from '../../../components/column_name_with_tooltip';
@@ -76,13 +76,9 @@ const baseColumns = [
       />
     ),
     truncateText: true,
-    width: '10%',
+    width: 160,
     sortable: true,
-    render: (filename: string) => (
-      <EuiToolTip position="top" content={filename} anchorClassName="eui-textTruncate">
-        <span>{filename}</span>
-      </EuiToolTip>
-    ),
+    render: (value) => <ShortIdBadge value={value} />,
   },
   {
     field: 'result.evaluation',
@@ -157,9 +153,18 @@ const baseColumns = [
         )}
       />
     ),
-    width: '10%',
+    width: 160,
     truncateText: true,
     sortable: true,
+    render: (value) => <ShortIdBadge value={value} />,
+  },
+  {
+    field: '_unique_id',
+    name: 'Finding ID',
+    width: 160,
+    truncateText: true,
+    sortable: true,
+    render: (value) => <ShortIdBadge value={value} />,
   },
   {
     field: '@timestamp',

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/utils/utils.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/utils/utils.ts
@@ -116,7 +116,7 @@ export const getFindingsPageSizeInfo = ({
 });
 
 export const getFindingsCountAggQuery = () => ({
-  count: { terms: { field: 'result.evaluation' } },
+  count: { terms: { field: 'result.evaluation.keyword' } },
 });
 
 export const getAggregationCount = (buckets: estypes.AggregationsStringRareTermsBucketKeys[]) => {

--- a/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/compliance_dashboard.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/compliance_dashboard.ts
@@ -23,14 +23,15 @@ export interface KeyDocCount<TKey = string> {
 const getClustersTrends = (clustersWithoutTrends: ClusterWithoutTrend[], trends: Trends) =>
   clustersWithoutTrends.map((cluster) => ({
     ...cluster,
-    trend: trends.map(({ timestamp, clusters: clustersTrendData }) => ({
+    trend: trends.map(({ snapshot, timestamp, clusters: clustersTrendData }) => ({
+      snapshot,
       timestamp,
       ...clustersTrendData[cluster.meta.clusterId],
     })),
   }));
 
 const getSummaryTrend = (trends: Trends) =>
-  trends.map(({ timestamp, summary }) => ({ timestamp, ...summary }));
+  trends.map(({ snapshot, timestamp, summary }) => ({ snapshot, timestamp, ...summary }));
 
 export const defineGetComplianceDashboardRoute = (router: CspRouter): void =>
   router.get(

--- a/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_trends.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_trends.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { SearchRequest } from '@elastic/elasticsearch/lib/api/types';
 import { ElasticsearchClient } from '@kbn/core/server';
 import { BENCHMARK_SCORE_INDEX_DEFAULT_NS } from '../../../common/constants';
 import { Stats } from '../../../common/types';
@@ -25,6 +26,73 @@ export interface ScoreTrendDoc {
   >;
 }
 
+const getScoreQuery = (): SearchRequest => ({
+  index: BENCHMARK_SCORE_INDEX_DEFAULT_NS,
+  size: 0,
+  aggs: {
+    aggs_by_snapshot: {
+      terms: {
+        field: 'snapshot_id',
+        size: 5,
+        order: { _key: 'desc' },
+      },
+      aggs: {
+        total_findings: {
+          value_count: {
+            field: 'result.evaluation.keyword',
+          },
+        },
+        timestamp: {
+          terms: {
+            field: '@timestamp',
+            size: 1,
+          },
+        },
+        passed_findings: {
+          filter: {
+            term: {
+              'result.evaluation.keyword': 'passed',
+            },
+          },
+        },
+        failed_findings: {
+          filter: {
+            term: {
+              'result.evaluation.keyword': 'failed',
+            },
+          },
+        },
+        score_by_cluster_id: {
+          terms: {
+            field: 'cluster_id',
+          },
+          aggregations: {
+            total_findings: {
+              value_count: {
+                field: 'result.evaluation.keyword',
+              },
+            },
+            passed_findings: {
+              filter: {
+                term: {
+                  'result.evaluation.keyword': 'passed',
+                },
+              },
+            },
+            failed_findings: {
+              filter: {
+                term: {
+                  'result.evaluation.keyword': 'failed',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+});
+
 export const getTrendsQuery = () => ({
   index: BENCHMARK_SCORE_INDEX_DEFAULT_NS,
   // large number that should be sufficient for 24 hours considering we write to the score index every 5 minutes
@@ -37,6 +105,30 @@ export const getTrendsQuery = () => ({
           '@timestamp': {
             gte: 'now-1d',
             lte: 'now',
+          },
+        },
+      },
+    },
+  },
+});
+
+const latestSnapshotsQuery = () => ({
+  index: BENCHMARK_SCORE_INDEX_DEFAULT_NS,
+  size: 0,
+  aggs: {
+    snapshots: {
+      terms: {
+        field: 'snapshot_id',
+      },
+      aggs: {
+        sorted_snapshots: {
+          bucket_sort: {
+            size: 5,
+            sort: [
+              {
+                _key: { order: 'desc' },
+              },
+            ],
           },
         },
       },
@@ -72,15 +164,51 @@ export const getTrendsFromQueryResult = (scoreTrendDocs: ScoreTrendDoc[]): Trend
     ),
   }));
 
-export const getTrends = async (esClient: ElasticsearchClient): Promise<Trends> => {
-  const trendsQueryResult = await esClient.search<ScoreTrendDoc>(getTrendsQuery());
+const getScoreTrendDocFromTrendsQueryResult = (trendsQueryResult: any): ScoreTrendDoc[] => {
+  const buckets = trendsQueryResult.aggregations.aggs_by_snapshot.buckets;
+  const scoreTrendDoc = buckets.map((bucket: any) => {
+    // console.log(bucket.score_by_cluster_id);
+    const timestamp = bucket.timestamp.buckets[0].key_as_string;
 
-  if (!trendsQueryResult.hits.hits) throw new Error('missing trend results from score index');
-
-  const scoreTrendDocs = trendsQueryResult.hits.hits.map((hit) => {
-    if (!hit._source) throw new Error('missing _source data for one or more of trend results');
-    return hit._source;
+    return {
+      '@timestamp': timestamp,
+      total_findings: bucket.total_findings.value,
+      passed_findings: bucket.passed_findings.doc_count,
+      failed_findings: bucket.failed_findings.doc_count,
+      score_by_cluster_id: bucket.score_by_cluster_id.buckets.reduce((acc, value) => {
+        acc = {
+          [value.key]: {
+            total_findings: value.total_findings.value,
+            passed_findings: value.passed_findings.doc_count,
+            failed_findings: value.failed_findings.doc_count,
+          },
+        };
+        return acc;
+      }, {}),
+    };
   });
 
-  return getTrendsFromQueryResult(scoreTrendDocs);
+  return scoreTrendDoc;
+};
+
+export const getTrends = async (esClient: ElasticsearchClient): Promise<Trends> => {
+  // const latestSnapshotsQueryResult = await esClient.search(latestSnapshotsQuery());
+  // console.log(latestSnapshotsQueryResult.aggregations.snapshots.buckets);
+  // const latestSnapshots = latestSnapshotsQueryResult.aggregations.snapshots.buckets.map(
+  //   (b) => b.key
+  // );
+  // console.log(latestSnapshots);
+  const trendsQueryResult = await esClient.search<ScoreTrendDoc>(getScoreQuery());
+  // console.log(trendsQueryResult.aggregations.aggs_by_snapshot.buckets);
+  const scoreTrendDoc = getScoreTrendDocFromTrendsQueryResult(trendsQueryResult);
+  // console.log(scoreTrendDoc)
+
+  // if (!trendsQueryResult.hits.hits) throw new Error('missing trend results from score index');
+  //
+  // const scoreTrendDocs = trendsQueryResult.hits.hits.map((hit) => {
+  //   if (!hit._source) throw new Error('missing _source data for one or more of trend results');
+  //   return hit._source;
+  // });
+
+  return getTrendsFromQueryResult(scoreTrendDoc);
 };

--- a/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_trends.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/compliance_dashboard/get_trends.ts
@@ -174,7 +174,7 @@ const getScoreTrendDocFromTrendsQueryResult = (trendsQueryResult: any): ScoreTre
   const scoreTrendDoc = buckets.map((bucket: any) => {
     // console.log(bucket.score_by_cluster_id);
     const timestamp = bucket.timestamp.buckets[0].key_as_string;
-    console.log(bucket);
+    // console.log(bucket);
     return {
       snapshot: bucket.key,
       '@timestamp': timestamp,
@@ -211,7 +211,7 @@ export const getTrends = async (esClient: ElasticsearchClient): Promise<Trends> 
   const scoreTrendDoc = getScoreTrendDocFromTrendsQueryResult(trendsQueryResult);
   // console.log(scoreTrendDoc)
 
-  console.log({ scoreTrendDoc });
+  // console.log({ scoreTrendDoc });
 
   // if (!trendsQueryResult.hits.hits) throw new Error('missing trend results from score index');
   //

--- a/x-pack/plugins/cloud_security_posture/server/tasks/findings_stats_task.ts
+++ b/x-pack/plugins/cloud_security_posture/server/tasks/findings_stats_task.ts
@@ -135,6 +135,7 @@ const aggregateLatestFindings = async (
   try {
     // const startAggTime = performance.now();
     // const evaluationsQueryResult = await esClient.search<unknown, ScoreBucket>(getScoreQuery());
+
     const snapshotQueryResult = await esClient.reindex({
       source: {
         index: LATEST_FINDINGS_INDEX_DEFAULT_NS,
@@ -147,7 +148,7 @@ const aggregateLatestFindings = async (
           'ctx._id = ctx._id + ctx._source["@timestamp"]; ctx._source.snapshot_id = params.snapshot_id;',
         lang: 'painless',
         params: {
-          snapshot_id: performance.now(),
+          snapshot_id: Date.now(),
         },
       },
     });

--- a/x-pack/plugins/cloud_security_posture/server/tasks/findings_stats_task.ts
+++ b/x-pack/plugins/cloud_security_posture/server/tasks/findings_stats_task.ts
@@ -31,151 +31,13 @@ const CSPM_FINDINGS_STATS_TASK_ID = 'cloud_security_posture-findings_stats';
 const CSPM_FINDINGS_STATS_TASK_TYPE = 'cloud_security_posture-stats_task';
 const CSPM_FINDINGS_STATS_INTERVAL = '5m';
 
-export async function scheduleFindingsStatsTask(
-  taskManager: TaskManagerStartContract,
-  logger: Logger
-) {
-  await scheduleTaskSafe(
-    taskManager,
-    {
-      id: CSPM_FINDINGS_STATS_TASK_ID,
-      taskType: CSPM_FINDINGS_STATS_TASK_TYPE,
-      schedule: {
-        interval: CSPM_FINDINGS_STATS_INTERVAL,
-      },
-      state: {},
-      params: {},
-    },
-    logger
-  );
-}
-
-export async function removeFindingsStatsTask(
-  taskManager: TaskManagerStartContract,
-  logger: Logger
-) {
-  await removeTaskSafe(taskManager, CSPM_FINDINGS_STATS_TASK_ID, logger);
-}
-
-export function setupFindingsStatsTask(
-  taskManager: TaskManagerSetupContract,
-  coreStartServices: CspServerPluginStartServices,
-  logger: Logger
-) {
-  try {
-    taskManager.registerTaskDefinitions({
-      [CSPM_FINDINGS_STATS_TASK_TYPE]: {
-        title: 'Aggregate latest findings index for score calculation',
-        createTaskRunner: taskRunner(coreStartServices, logger),
-      },
-    });
-    logger.info(`Registered task successfully [Task: ${CSPM_FINDINGS_STATS_TASK_TYPE}]`);
-  } catch (errMsg) {
-    const error = transformError(errMsg);
-    logger.error(
-      `Task registration failed [Task: ${CSPM_FINDINGS_STATS_TASK_TYPE}] ${error.message}`
-    );
-  }
-}
-
-export function taskRunner(coreStartServices: CspServerPluginStartServices, logger: Logger) {
-  return ({ taskInstance }: RunContext) => {
-    const { state } = taskInstance;
-    return {
-      async run(): Promise<FindingsStatsTaskResult> {
-        try {
-          logger.info(`Runs task: ${CSPM_FINDINGS_STATS_TASK_TYPE}`);
-          const esClient = (await coreStartServices)[0].elasticsearch.client.asInternalUser;
-          const status = await aggregateLatestFindings(esClient, state.runs, logger);
-
-          return {
-            state: {
-              runs: (state.runs || 0) + 1,
-              health_status: status,
-            },
-          };
-        } catch (errMsg) {
-          const error = transformError(errMsg);
-          logger.warn(`Error executing alerting health check task: ${error.message}`);
-          return {
-            state: {
-              runs: (state.runs || 0) + 1,
-              health_status: 'error',
-            },
-          };
-        }
-      },
-    };
-  };
-}
-
-const aggregateLatestFindings = async (
-  esClient: ElasticsearchClient,
-  stateRuns: number,
-  logger: Logger
-): Promise<TaskHealthStatus> => {
-  try {
-    const startAggTime = performance.now();
-    const evaluationsQueryResult = await esClient.search<unknown, ScoreBucket>(getScoreQuery());
-
-    if (!evaluationsQueryResult.aggregations) {
-      logger.warn(`No data found in latest findings index`);
-      return 'warning';
-    }
-
-    const totalAggregationTime = performance.now() - startAggTime;
-    logger.debug(
-      `Executed aggregation query [Task: ${CSPM_FINDINGS_STATS_TASK_TYPE}] [Duration: ${Number(
-        totalAggregationTime
-      ).toFixed(2)}ms]`
-    );
-
-    const clustersStats = Object.fromEntries(
-      evaluationsQueryResult.aggregations.score_by_cluster_id.buckets.map(
-        (clusterStats: AggregatedFindingsByCluster) => {
-          return [
-            clusterStats.key,
-            {
-              total_findings: clusterStats.total_findings.value,
-              passed_findings: clusterStats.passed_findings.doc_count,
-              failed_findings: clusterStats.failed_findings.doc_count,
-            },
-          ];
-        }
-      )
-    );
-
-    const startIndexTime = performance.now();
-    await esClient.index({
-      index: BENCHMARK_SCORE_INDEX_DEFAULT_NS,
-      document: {
-        passed_findings: evaluationsQueryResult.aggregations.passed_findings.doc_count,
-        failed_findings: evaluationsQueryResult.aggregations.failed_findings.doc_count,
-        total_findings: evaluationsQueryResult.aggregations.total_findings.value,
-        score_by_cluster_id: clustersStats,
-      },
-    });
-
-    const totalIndexTime = Number(performance.now() - startIndexTime).toFixed(2);
-    logger.debug(
-      `Finished saving results [Task: ${CSPM_FINDINGS_STATS_TASK_TYPE}] [Duration: ${totalIndexTime}ms]`
-    );
-
-    const totalTaskTime = Number(performance.now() - startAggTime).toFixed(2);
-    logger.debug(
-      `Finished run ended [Task: ${CSPM_FINDINGS_STATS_TASK_TYPE}] [Duration: ${totalTaskTime}ms]`
-    );
-
-    return 'ok';
-  } catch (errMsg) {
-    const error = transformError(errMsg);
-    logger.error(
-      `Failure during task run [Task: ${CSPM_FINDINGS_STATS_TASK_TYPE}] ${error.message}`
-    );
-    logger.error(errMsg);
-    return 'error';
-  }
-};
+const getSnapshotQuery = (): SearchRequest => ({
+  index: LATEST_FINDINGS_INDEX_DEFAULT_NS,
+  size: 0,
+  query: {
+    match_all: {},
+  },
+});
 
 const getScoreQuery = (): SearchRequest => ({
   index: LATEST_FINDINGS_INDEX_DEFAULT_NS,
@@ -231,3 +93,167 @@ const getScoreQuery = (): SearchRequest => ({
     },
   },
 });
+
+export async function scheduleFindingsStatsTask(
+  taskManager: TaskManagerStartContract,
+  logger: Logger
+) {
+  await scheduleTaskSafe(
+    taskManager,
+    {
+      id: CSPM_FINDINGS_STATS_TASK_ID,
+      taskType: CSPM_FINDINGS_STATS_TASK_TYPE,
+      schedule: {
+        interval: CSPM_FINDINGS_STATS_INTERVAL,
+      },
+      state: {},
+      params: {},
+    },
+    logger
+  );
+}
+
+export async function removeFindingsStatsTask(
+  taskManager: TaskManagerStartContract,
+  logger: Logger
+) {
+  await removeTaskSafe(taskManager, CSPM_FINDINGS_STATS_TASK_ID, logger);
+}
+
+export function setupFindingsStatsTask(
+  taskManager: TaskManagerSetupContract,
+  coreStartServices: CspServerPluginStartServices,
+  logger: Logger
+) {
+  try {
+    taskManager.registerTaskDefinitions({
+      [CSPM_FINDINGS_STATS_TASK_TYPE]: {
+        title: 'Aggregate latest findings index for score calculation',
+        createTaskRunner: taskRunner(coreStartServices, logger),
+      },
+    });
+    logger.info(`Registered task successfully [Task: ${CSPM_FINDINGS_STATS_TASK_TYPE}]`);
+  } catch (errMsg) {
+    const error = transformError(errMsg);
+    logger.error(
+      `Task registration failed [Task: ${CSPM_FINDINGS_STATS_TASK_TYPE}] ${error.message}`
+    );
+  }
+}
+
+const aggregateLatestFindings = async (
+  esClient: ElasticsearchClient,
+  stateRuns: number,
+  logger: Logger
+): Promise<TaskHealthStatus> => {
+  try {
+    const startAggTime = performance.now();
+    const evaluationsQueryResult = await esClient.search<unknown, ScoreBucket>(getScoreQuery());
+    const snapshotQueryResult = await esClient.reindex({
+      source: {
+        index: LATEST_FINDINGS_INDEX_DEFAULT_NS,
+      },
+      dest: {
+        index: BENCHMARK_SCORE_INDEX_DEFAULT_NS,
+      },
+      script: {
+        source: 'ctx._id = ctx._id + ctx._source["@timestamp"]; ctx.batch_id = params.batch_id;',
+        lang: 'painless',
+        params: {
+          batch_id: performance.now(),
+        },
+      },
+    });
+
+    // console.log(snapshotQueryResult);
+
+    if (!evaluationsQueryResult.aggregations) {
+      logger.warn(`No data found in latest findings index`);
+      return 'warning';
+    }
+
+    const totalAggregationTime = performance.now() - startAggTime;
+    logger.debug(
+      `Executed aggregation query [Task: ${CSPM_FINDINGS_STATS_TASK_TYPE}] [Duration: ${Number(
+        totalAggregationTime
+      ).toFixed(2)}ms]`
+    );
+
+    const clustersStats = Object.fromEntries(
+      evaluationsQueryResult.aggregations.score_by_cluster_id.buckets.map(
+        (clusterStats: AggregatedFindingsByCluster) => {
+          return [
+            clusterStats.key,
+            {
+              total_findings: clusterStats.total_findings.value,
+              passed_findings: clusterStats.passed_findings.doc_count,
+              failed_findings: clusterStats.failed_findings.doc_count,
+            },
+          ];
+        }
+      )
+    );
+
+    const startIndexTime = performance.now();
+
+    // await esClient.index({
+    //   index: BENCHMARK_SCORE_INDEX_DEFAULT_NS,
+    //   document: {
+    //     passed_findings: evaluationsQueryResult.aggregations.passed_findings.doc_count,
+    //     failed_findings: evaluationsQueryResult.aggregations.failed_findings.doc_count,
+    //     total_findings: evaluationsQueryResult.aggregations.total_findings.value,
+    //     score_by_cluster_id: clustersStats,
+    //   },
+    // });
+
+    const totalIndexTime = Number(performance.now() - startIndexTime).toFixed(2);
+    logger.debug(
+      `Finished saving results [Task: ${CSPM_FINDINGS_STATS_TASK_TYPE}] [Duration: ${totalIndexTime}ms]`
+    );
+
+    const totalTaskTime = Number(performance.now() - startAggTime).toFixed(2);
+    logger.debug(
+      `Finished run ended [Task: ${CSPM_FINDINGS_STATS_TASK_TYPE}] [Duration: ${totalTaskTime}ms]`
+    );
+
+    return 'ok';
+  } catch (errMsg) {
+    const error = transformError(errMsg);
+    logger.error(
+      `Failure during task run [Task: ${CSPM_FINDINGS_STATS_TASK_TYPE}] ${error.message}`
+    );
+    logger.error(errMsg);
+    return 'error';
+  }
+};
+
+export function taskRunner(coreStartServices: CspServerPluginStartServices, logger: Logger) {
+  return ({ taskInstance }: RunContext) => {
+    const { state } = taskInstance;
+    return {
+      async run(): Promise<FindingsStatsTaskResult> {
+        try {
+          logger.info(`Runs task: ${CSPM_FINDINGS_STATS_TASK_TYPE}`);
+          const esClient = (await coreStartServices)[0].elasticsearch.client.asInternalUser;
+          const status = await aggregateLatestFindings(esClient, state.runs, logger);
+
+          return {
+            state: {
+              runs: (state.runs || 0) + 1,
+              health_status: status,
+            },
+          };
+        } catch (errMsg) {
+          const error = transformError(errMsg);
+          logger.warn(`Error executing alerting health check task: ${error.message}`);
+          return {
+            state: {
+              runs: (state.runs || 0) + 1,
+              health_status: 'error',
+            },
+          };
+        }
+      },
+    };
+  };
+}

--- a/x-pack/plugins/cloud_security_posture/server/tasks/findings_stats_task.ts
+++ b/x-pack/plugins/cloud_security_posture/server/tasks/findings_stats_task.ts
@@ -157,7 +157,8 @@ const aggregateLatestFindings = async (
         index: BENCHMARK_SCORE_INDEX_DEFAULT_NS,
       },
       script: {
-        source: 'ctx._id = ctx._id + ctx._source["@timestamp"]; ctx.batch_id = params.batch_id;',
+        source:
+          'ctx._id = ctx._id + ctx._source["@timestamp"]; ctx._source.batch_id = params.batch_id;',
         lang: 'painless',
         params: {
           batch_id: performance.now(),


### PR DESCRIPTION
# The Problem

![image](https://user-images.githubusercontent.com/51442161/187886433-a01a5e6f-da29-49bc-a64c-57f86aee1d05.png)

Let's imagine a very basic scenario, one of your findings that used to pass is now failing.
In our current system, we only show the latest state of the findings, so how do you debug that? how do you even know it happened?

If you got a few hundred findings, the posture score wouldn't change, and the trend line would barely move. 
Even if you would remember that you had "392 passed findings out of 410" and now you have "391 passed findings out of 410", how do you even know which one has failed?

Even worse, what if one will fail but another will pass? effectively you won't even be able to know anything happened unless you remember all of your findings.

Now let's imagine that you actually found the problematic finding that changed from `passed` to `failed`. We do not provide debugging tools for the user, he knows that this finding has changed cause he somehow remembered that it used to pass, but what changed? how can he know what values changed?

# The Solution

Keeping track of findings in batches, this essentially provides us with an investigation over time capabilities.
Instead of saving just the latest state, we save the state every few minutes. we can then compare between states to locate changes, alert the user of specific finding changes, and provide him the tools to understand what changed and when.

To do that, I've took a snapshot from the `latest-findings` index every few minutes, I've used the `elasticSearchClient.reindex` method which allows us to reindex an index into another index and optionally make some changes.
I've used a `Painless` script to do a few things:
- Create a uniqe doc `_id` to prevent the documents from getting updated instead of re-created
- Add a common `snapshot_id` to all documents so we can filter and group them togehter
- Add a `_unique_id` to each finding, `resource.id` + `rule.id`, for specific investigation of single finding over time   

![image](https://user-images.githubusercontent.com/51442161/187890424-dc094d6d-3faf-4cdc-a3a2-cba52b15f597.png)

### `latest-findings` Index
![image](https://user-images.githubusercontent.com/51442161/187889590-fb9b84e5-83a3-48de-867a-184868057f18.png)

### `snapshots` index
![image](https://user-images.githubusercontent.com/51442161/187889526-12bd445e-bb74-486a-8294-be0626bb25b5.png)

# Timebased Cloud Posture 

## Dashboard 2.0
- All elements in the dashboard are still clickable and will navigate to the latest snapshot
- Clicking on the trend line is now also an option, clicking on a past time where we saw a drop for example to investigate this specific time point  
- Every finding change will be tracked and notified on a notification center in the dashboard.
- Clicking on a notification will navigate to `Findings`, filtered by the new `_unique_id` and the latest `snapshots_id`s where the change was detected


https://user-images.githubusercontent.com/51442161/187900720-3b3e0328-b575-49b5-b699-18f5f119efc4.mp4



## Findings 2.0
- Now has a drop-down to select a snapshot to watch, we can alert the user every time a new snapshot is available.
- Displays a `Finding ID` column, which is a single unique factor among all snapshots, meaning we see the exact same finding across multiple time points.
- Uses a new `ShortIdBadge` to save space, only displaying the first section of the ID, clicking on the badge will copy the full ID

https://user-images.githubusercontent.com/51442161/187902189-e2c5f21b-e677-4331-b3ce-d81114ef4f8c.mov

## Flyout 2.0
- New `Timeline` tab is now available for each finding, displaying the evaluation change at each timepoint
- If a change was detected, it can be investigated in the timeline component
- In the future, we can also suggest auto alerting on further changes, and remediate the problem directly from Kibana
- For now we can click on `Investigate` to compare the previous and current state of the finding and better understand what changed.
- If i had more time I'd also add a `diff` component, but for now we can use [jsonDiff](https://jsondiff.com/) to see diffs
![image](https://user-images.githubusercontent.com/51442161/187908593-68f1ede4-d47f-493a-a8a9-f8039eba50bd.png)


https://user-images.githubusercontent.com/51442161/187903452-237197eb-7fe5-47f2-a389-52659f6dc27f.mp4


