### PR TITLE
Adds related entity field for generic entities

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/entity_analytics/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/entity_analytics/types.ts
@@ -23,6 +23,7 @@ export enum EntityIdentifierFields {
   userName = 'user.name',
   serviceName = 'service.name',
   generic = 'entity.id',
+  related = 'related.entity',
 }
 
 export const EntityTypeToIdentifierField: Record<EntityType, EntityIdentifierFields> = {

--- a/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/entity_insight.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/components/entity_insight.tsx
@@ -23,7 +23,10 @@ import type { EntityDetailsPath } from '../../flyout/entity_details/shared/compo
 
 export type CloudPostureEntityIdentifier = Extract<
   EntityIdentifierFields,
-  EntityIdentifierFields.hostName | EntityIdentifierFields.userName | EntityIdentifierFields.generic
+  | EntityIdentifierFields.hostName
+  | EntityIdentifierFields.userName
+  | EntityIdentifierFields.generic
+  | EntityIdentifierFields.related
 >;
 
 export const EntityInsight = <T,>({

--- a/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/hooks/use_non_closed_alerts.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/hooks/use_non_closed_alerts.ts
@@ -7,6 +7,7 @@
 
 import { useMemo } from 'react';
 import { FILTER_CLOSED } from '@kbn/securitysolution-data-table/common/types';
+import { EntityIdentifierFields } from '../../../common/entity_analytics/types';
 import { useSignalIndex } from '../../detections/containers/detection_engine/alerts/use_signal_index';
 import { useAlertsByStatus } from '../../overview/components/detection_response/alerts_by_status/use_alerts_by_status';
 import type { ParsedAlertsData } from '../../overview/components/detection_response/alerts_by_status/types';
@@ -35,6 +36,11 @@ export const useNonClosedAlerts = ({
     queryId,
     to,
     from,
+    runtimeMappings: {
+      [EntityIdentifierFields.related]: {
+        type: 'keyword',
+      },
+    },
   });
 
   const filteredAlertsData: ParsedAlertsData = alertsData

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/generic_right/hooks/use_open_generic_entity_details_left_panel.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/generic_right/hooks/use_open_generic_entity_details_left_panel.ts
@@ -36,6 +36,11 @@ export const useOpenGenericEntityDetailsLeftPanel = ({
     to,
     from,
     queryId: `${DETECTION_RESPONSE_ALERTS_BY_STATUS_ID}-generic-entity-alerts`,
+    runtimeMappings: {
+      'related.entity': {
+        type: 'keyword',
+      },
+    },
   });
 
   const openGenericEntityDetails = (path: EntityDetailsPath) => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/generic_right/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/generic_right/index.tsx
@@ -65,7 +65,7 @@ export const GenericEntityPanel = ({ entityDocId, scopeId }: GenericEntityPanelP
   });
 
   const { openGenericEntityDetails } = useOpenGenericEntityDetailsLeftPanel({
-    field: EntityIdentifierFields.generic,
+    field: EntityIdentifierFields.related,
     value: getGenericEntity.data?._source?.entity.id || '',
     entityDocId,
     scopeId,

--- a/x-pack/solutions/security/plugins/security_solution/public/overview/components/detection_response/alerts_by_status/use_alerts_by_status.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/overview/components/detection_response/alerts_by_status/use_alerts_by_status.ts
@@ -41,11 +41,13 @@ export const getAlertsByStatusQuery = ({
   from,
   to,
   entityFilter,
+  runtimeMappings,
 }: {
   from: string;
   to: string;
   entityFilter?: EntityFilter;
   additionalFilters?: ESBoolQuery[];
+  runtimeMappings?: Record<string, unknown>;
 }) => ({
   size: 0,
   query: {
@@ -79,6 +81,7 @@ export const getAlertsByStatusQuery = ({
       },
     },
   },
+  ...(runtimeMappings ? { runtime_mappings: runtimeMappings } : {}),
 });
 
 export const parseAlertsData = (
@@ -115,6 +118,7 @@ export interface UseAlertsByStatusProps {
   additionalFilters?: ESBoolQuery[];
   from: string;
   to: string;
+  runtimeMappings?: Record<string, unknown>;
 }
 
 export type UseAlertsByStatus = (props: UseAlertsByStatusProps) => {
@@ -131,6 +135,7 @@ export const useAlertsByStatus: UseAlertsByStatus = ({
   skip = false,
   to,
   from,
+  runtimeMappings = {},
 }) => {
   const dispatch = useDispatch();
   const [updatedAt, setUpdatedAt] = useState(Date.now());
@@ -168,6 +173,7 @@ export const useAlertsByStatus: UseAlertsByStatus = ({
       to,
       entityFilter,
       additionalFilters,
+      runtimeMappings,
     }),
     indexName: signalIndexName,
     skip,
@@ -181,8 +187,10 @@ export const useAlertsByStatus: UseAlertsByStatus = ({
         to,
         entityFilter,
         additionalFilters,
+        runtimeMappings,
       })
     );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [setAlertsQuery, from, to, entityFilter, additionalFilters]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary 

Extends entity analytics of generic flyouts to use the `related.entity` field for querying 

## Screenshot

<img width="1495" alt="image" src="https://github.com/user-attachments/assets/9a0028d5-6ba3-4d5e-a812-8554fa3e0e22" />
